### PR TITLE
Fix game manager autoload singleton error

### DIFF
--- a/scripts/autoload/game_manager.gd
+++ b/scripts/autoload/game_manager.gd
@@ -1,7 +1,6 @@
 extends Node
 
 # Game Manager - Main autoload for game state management
-class_name GameManager
 
 signal game_state_changed(new_state)
 signal elements_changed(new_amount)


### PR DESCRIPTION
Remove redundant `class_name` from `GameManager` autoload to fix parser error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ea6fcc9-6552-400c-8a83-c59ebdc702ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ea6fcc9-6552-400c-8a83-c59ebdc702ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

